### PR TITLE
Fixed overlapping element issue in settings panel.

### DIFF
--- a/addon/globalPlugins/wordNav.py
+++ b/addon/globalPlugins/wordNav.py
@@ -205,16 +205,16 @@ class SettingsDialog(SettingsPanel):
 
       # bulkyWordPunctuation
         # Translators: Label for bulkyWordPunctuation edit box
-        self.bulkyWordPunctuationEdit = gui.guiHelper.LabeledControlHelper(self, _("Bulky word separators:"), wx.TextCtrl).control
+        self.bulkyWordPunctuationEdit = sHelper.addLabeledControl(_("Bulky word separators:"), wx.TextCtrl)
         self.bulkyWordPunctuationEdit.Value = getConfig("bulkyWordPunctuation")
       # MultiWord word count
         # Translators: Label for multiWord wordCount edit box
-        self.wordCountEdit = gui.guiHelper.LabeledControlHelper(self, _("Word count for multiWord navigation:"), wx.TextCtrl).control
+        self.wordCountEdit = sHelper.addLabeledControl(_("Word count for multiWord navigation:"), wx.TextCtrl)
         self.wordCountEdit.Value = str(getConfig("wordCount"))
 
       # applicationsBlacklist edit
         # Translators: Label for blacklisted applications edit box
-        self.applicationsBlacklistEdit = gui.guiHelper.LabeledControlHelper(self, _("Disable WordNav in applications (comma-separated list)"), wx.TextCtrl).control
+        self.applicationsBlacklistEdit = sHelper.addLabeledControl(_("Disable WordNav in applications (comma-separated list)"), wx.TextCtrl)
         self.applicationsBlacklistEdit.Value = getConfig("applicationsBlacklist")
 
     def onSave(self):


### PR DESCRIPTION
Hi Tony

Here is a PR to fix the layout in wordNav settings panel.

### Issue

The 3 last edit fields of the panel overlap the first checkbox of the panel. That's why these objects are created but they have no specific information to define their position. Thus they show up at the top left corner of the panel.

### Solution

Use sHelper.addLabeledControl as for combo-boxes so that the GUI helper manages automatically the position of these controls.

### Tests performed

Checked visually the layout of the panel.
Note: I did not check the overall good working of the add-on. Please, double check. But given the modifications, it should not change anything.



