### PR TITLE
Fixed case where simulated Ctrl+arrows were not captured. Closed #14

### DIFF
--- a/addon/globalPlugins/wordNav.py
+++ b/addon/globalPlugins/wordNav.py
@@ -564,7 +564,7 @@ def getModifiers(gesture):
     control = None
     windows = False
     for modVk, modExt in gesture.modifiers:
-        if modVk == winUser.VK_LCONTROL:
+        if modVk == winUser.VK_LCONTROL or modVk == winUser.VK_CONTROL:
             control = 'left'
         if modVk == winUser.VK_RCONTROL:
             control = 'right'


### PR DESCRIPTION
Because we did not capture the VK_CONTROL case, ctrl+Left/Right arrow  failed.

I just changed ` if modVk == winUser.VK_LCONTROL:` in `getModifiers` to ` if modVk == winUser.VK_LCONTROL or modVk == winUser.VK_CONTROL:`.

cc @mltony 