### PR TITLE
Fix RuntimeError in isVscodeApp Function

### DIFF
--- a/addon/globalPlugins/wordNav.py
+++ b/addon/globalPlugins/wordNav.py
@@ -597,9 +597,10 @@ def isVscodeApp(self):
     try:
         if self.treeInterceptor is not None:
             return False
-    except NameError:
+        return self.appModule.productName.startswith("Visual Studio Code")
+    except (NameError, AttributeError, RuntimeError) as e:
+        mylog(f"Error in isVscodeApp: {str(e)}")
         return False
-    return self.appModule.productName.startswith("Visual Studio Code")
 
 def isVSCodeMainEditor(obj):
     if obj.role != controlTypes.Role.EDITABLETEXT:


### PR DESCRIPTION
## Description:
Fixed #16

This pull request addresses an issue where the `isVscodeApp` function within the WordNav NVDA add-on throws a `RuntimeError` when it fails to access `self.appModule.productName` due to missing version information. The proposed changes add error handling to manage such exceptions.

## Changes Made:
• Added `RuntimeError` and `AttributeError` to the existing try-except block to catch and handle runtime errors during product name access.
• Included logging for the error to aid in future diagnostics and debugging.

## Benefits:
• Prevents the add-on from crashing when encountering missing version information in certain applications.

## Test Plan:
Verify that the add-on no longer crashes when navigating to applications without version information.

## Notes
If you merge this PR and want to publish a new version, I recommend doing so this Saturday. At that time, we can update the localization translation to the latest.

Of course, you can also leave it entirely to me. 
Do you have any other suggestions, PLMK.

cc @mltony 
