### PR TITLE
Fix WordNav crash after add-on reload

### DIFF
--- a/addon/globalPlugins/wordNav.py
+++ b/addon/globalPlugins/wordNav.py
@@ -516,12 +516,12 @@ def asyncUpdateNotepadPPCursorWhenModifiersReleased(doRight, localGestureCounter
         keystroke.send()
 
 
-def isBlacklistedApp(self):
-    focus = self
-    appName = focus.appModule.appName
-    if appName.lower() in getConfig("applicationsBlacklist").lower().strip().split(","):
-        return True
-    return False
+def isBlacklistedApp(obj):
+	"""Return whether WordNav is disabled for the object's application."""
+	appModule = getattr(obj, "appModule", None)
+	if appModule is None:
+		return False
+	return appModule.appName.lower() in getConfig("applicationsBlacklist").lower().strip().split(",")
 
 
 def getUrl(obj):


### PR DESCRIPTION
## Problem

After add-ons are reloaded, NVDA can temporarily return `None` for an existing object's `appModule`.

WordNav's application blocklist check dereferenced `obj.appModule.appName`, which caused an `AttributeError` when word navigation was used immediately after reload.

## Fix

Guard `isBlacklistedApp` for a missing `appModule`. If application metadata is unavailable, WordNav treats the app as not blocklisted and continues normal navigation.
